### PR TITLE
fix: removes app id, and allows all traffic

### DIFF
--- a/src/ancillary_resources/terraform/azure/key_vault.tf
+++ b/src/ancillary_resources/terraform/azure/key_vault.tf
@@ -18,7 +18,6 @@ resource "azurerm_key_vault" "kv" {
   access_policy {
     tenant_id      = data.azurerm_client_config.service_principal.tenant_id
     object_id      = data.azurerm_client_config.service_principal.object_id
-    application_id = data.azurerm_client_config.service_principal.client_id
 
     secret_permissions      = var.key_vault_secret_perms
     certificate_permissions = var.key_vault_cert_perms
@@ -27,7 +26,7 @@ resource "azurerm_key_vault" "kv" {
   }
 
   network_acls {
-    default_action = "Deny"
+    default_action = "Allow"
     bypass         = "AzureServices"
   }
 

--- a/src/ancillary_resources/terraform/azure/key_vault.tf
+++ b/src/ancillary_resources/terraform/azure/key_vault.tf
@@ -16,8 +16,8 @@ resource "azurerm_key_vault" "kv" {
   tenant_id = data.azurerm_client_config.service_principal.tenant_id
 
   access_policy {
-    tenant_id      = data.azurerm_client_config.service_principal.tenant_id
-    object_id      = data.azurerm_client_config.service_principal.object_id
+    tenant_id = data.azurerm_client_config.service_principal.tenant_id
+    object_id = data.azurerm_client_config.service_principal.object_id
 
     secret_permissions      = var.key_vault_secret_perms
     certificate_permissions = var.key_vault_cert_perms


### PR DESCRIPTION
#### 📲 What

 * Fixes On Behalf Of errors, by removing App ID (App ID is only used for On Behalf Of uses it seems)
 * Fixes traffic being denied from AzDo, by allowing all traffic (AzureServices doesn't seem to include AzDo)

#### 🤔 Why
		
When the pipeline is run, the builds that need to use the KeyVault fail until the Internet is allowed, and the Service Principal is added to the KV. This is because setting an App ID sets the policy as an On Behalf Of Role Assignment instead of direct.
		
#### 🛠 How

#### 👀 Evidence
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
